### PR TITLE
memory leak in __rds_conn_create()

### DIFF
--- a/net/rds/connection.c
+++ b/net/rds/connection.c
@@ -253,6 +253,7 @@ static struct rds_connection *__rds_conn_create(struct net *net,
 				 * should end up here, but if it
 				 * does, reset/destroy the connection.
 				 */
+				kfree(conn->c_path);
 				kmem_cache_free(rds_conn_slab, conn);
 				conn = ERR_PTR(-EOPNOTSUPP);
 				goto out;


### PR DESCRIPTION
This PR fixes a potential security vulnerability in `__rds_conn_create` that was cloned from `torvalds/linux` but did not receive the security patch.

**Vulnerability Details:**

* **Affected Function**: `__rds_conn_create` in `net/rds/connection.c`
* **Original Fix**: https://github.com/torvalds/linux/commit/5f9562ebe710c307adc5f666bf1a2162ee7977c0

**What this PR does:** This PR applies the same security patch that was applied to the original repository to eliminate the potential vulnerability in the cloned code.

**References:**

* https://github.com/torvalds/linux/commit/5f9562ebe710c307adc5f666bf1a2162ee7977c0
* [CVE-2021-45480](https://nvd.nist.gov/vuln/detail/cve-2021-45480)

Please review and merge this PR to ensure your repository is protected against this vulnerability.